### PR TITLE
Update teams.md

### DIFF
--- a/1.x/features/teams.md
+++ b/1.x/features/teams.md
@@ -27,6 +27,28 @@ When using the Livewire stack, the team creation view is displayed using the `re
 
 Team creation and deletion logic may be customized by modifying the relevant action classes within your `app/Actions/Jetstream` directory. These actions include `CreateTeam`, `UpdateTeamName`, and `DeleteTeam`. Each of these actions is invoked when their corresponding task is performed by the user in the application's UI. You are free to modify these actions as needed based on your application's needs.
 
+Execute code when a Team is created / deleted from the web interface or through Team class API.
+
+When a Team is created either from the web interface of Jetstream or through a REST API call directly, it is required sometimes to execute some initialization code. For example, populate a units_of_measure table with default values for the new Team. 
+
+Adding a boot() function inside the Team.php class you can execute initialization code when a Team is created or deleted 
+
+```php
+class Team extends JetstreamTeam
+{
+
+    protected static function boot()
+    {
+        parent::boot();
+        
+        Team::created(function ($model) {
+            UnitOfMeasureController::insert_default_units_of_measure_data($model);
+        });
+    }
+
+  } //Team.php class
+  ```
+
 ## Inspecting User Teams
 
 Information about a user's teams may be accessed via the methods provided by the `Laravel\Jetstream\HasTeams` trait. This trait is automatically applied to your application's `App\Models\User` model during Jetstream's installation. This trait provides a variety of helpful methods that allow you to inspect a user's teams:
@@ -104,6 +126,9 @@ $team->hasUserWithEmail($emailAddress) : bool
 
 // Determine if the given user is a team member with the given permission...
 $team->userHasPermission($user, $permission) : bool
+
+// Delete a Team and detach related users
+$team->purge()
 ```
 
 ## Member Management


### PR DESCRIPTION
**1. Execute code when a Team is created / deleted from the web interface or through Team class API.**

When a Team is created either from the web interface of Jetstream or through a REST API call directly, it is required sometimes to execute some initialisation code. For example, populate a units_of_measure table with default values for the new Team. 

What I found working is to add a boot() function inside the Team.php class and execute initialization code there when a Team is created, but is this the correct way to do it? 

```php
class Team extends JetstreamTeam
{

    protected static function boot()
    {
        parent::boot();
        
        Team::created(function ($model) {
            UnitOfMeasureController::insert_default_units_of_measure_data($model);
        });
    }

  } //Team.php class
```


**2. How to delete a Team using an API call?**
I found that inside jetstream/src/Team.php there is a purge() method that does this and it is not included in the documentation.


**3. Roles** are a very important and useful part of Teams but it is static. In most real world scenarios roles are kept in a database table with the required columns for each role permission and the end user can add roles to the table with the required permissions and attach these roles to the Teams. 
What is the correct way to do this in Jetstream ?   would it be a good option the modify protected function configurePermissions() inside JetstreamServiceProvider.php  and instead of the static configurePermissions() implementation, configure each Jetstream::role by pulling the data from a roles table?


Overall the design of Jetstream is excellent and it should not be polluted with every small possible requirement, but only with what most people use in real world applications. There is no need to hurry at the moment. We should start using it in our projects and improve it based on actually requirements.